### PR TITLE
Multiple ids

### DIFF
--- a/R/bagit.R
+++ b/R/bagit.R
@@ -24,16 +24,15 @@ bagit_query <- function(id,
 #' @importFrom fs file_info path_abs
 format_bagit <- function(df, dir = content_dir()) {
   if (ncol(df) == 0 || nrow(df) == 0) {
-    return(data.frame(identifier = NA, source = NA, date = NA)[0, ])
+    return( registry_entry()[0, ])
   }
-  names(df) <- c("identifier", "source")
+  
   abs_path <- fs::path_abs(df$source, start = dir)
-  df$identifier <- add_prefix(df$identifier)
-  # fs, readr, & others do not handle file URIs well!
-  # https://github.com/r-lib/fs/issues/245
-  df$source <- abs_path # paste0("file://", abs_path)
-  df$date <- fs::file_info(abs_path)$modification_time
-  df
+  registry_entry(id = add_prefix(df$identifier),
+                 source = abs_path,
+                 date = fs::file_info(abs_path)$modification_time
+                 )
+  
 }
 
 

--- a/R/content-uri.R
+++ b/R/content-uri.R
@@ -47,7 +47,9 @@ content_id_ <- function(file, open = "", raw = TRUE) {
   
   con <- stream_connection(file, open = open, raw = raw)
   
-  ## Could support other hash types
+  ## Could support other hash types while still streaming
+  ## see https://github.com/cboettig/contentid/issues/38
+  
   hash <- openssl::sha256(con)
   paste0("hash://sha256/", as.character(hash))
 }

--- a/R/format_identifiers.R
+++ b/R/format_identifiers.R
@@ -1,0 +1,68 @@
+
+
+as_hashuri <- function(x){
+  # Named Info, https://tools.ietf.org/html/rfc6920
+  if(grepl("^ni://", x))
+    return( from_ni(x) )
+  
+  # magnet URI
+  if(grepl("^magnet:\\?xt=urn:", x))
+    return(from_magnet(x))
+  
+  # SSB
+  if(grepl("^\\&", x))
+    return(from_ssb(x))
+  
+  ## Subresource registry
+  if(grepl(paste0(algo_regex, "-", base64_regex), x))
+    return(from_subresource_registry(x))
+  
+}
+
+algo_regex <- "(sha[0-9]{1,3}|md5)"
+base64_regex <- "((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)"
+hex_regex <- "((0x|0X)?[a-fA-F0-9]+)"
+
+#' x <- "sha256-lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc="
+from_subresource_registry <- function(x){
+  hash <- gsub(paste0(algo_regex, "-", base64_regex), "\\2", x)
+  algo <- gsub(paste0(algo_regex, "-", base64_regex), "\\1", x)
+  hex <- paste0(openssl::base64_decode(hash), collapse = "")
+  paste0("hash://", algo, "/", hex)
+  
+}
+
+#' x <- "&lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc=.sha256"
+from_ssb <- function(x){
+  
+  pattern <- paste0("\\&", base64_regex, "\\.", algo_regex)
+  hash <- gsub(pattern, "\\1", x)
+  algo <- gsub(pattern, "\\2", x)
+  hex <- paste0(openssl::base64_decode(hash), collapse = "")
+  paste0("hash://", algo, "/", hex)
+  
+}
+
+#'   x <- "ni:///sha256;lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc"
+from_ni <- function(x){
+  
+  #pattern <- paste0("^ni:///", algo_regex,  ";", base64_regex)
+  
+  hash <-  gsub(paste0("^ni:///([a-zA-Z0-9]+);", base64_regex), "\\2", x)
+  algo <- gsub(paste0("^ni:///", algo_regex,  ";", hash), "\\1", x)
+  hex <- paste0(openssl::base64_decode(hash), collapse = "")
+  paste0("hash://", algo, "/", hex)
+
+}
+
+#' x <- "magnet:?xt=urn:sha256:9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37"
+from_magnet <- function(x){
+  
+  pattern <- paste0("^magnet:\\?xt=urn:", algo_regex, ":", hex_regex)
+  algo <- gsub(pattern, "\\1", x)
+  hex <-  gsub(pattern, "\\2", x)
+  paste0("hash://", algo, "/", hex)
+  
+  
+    
+}

--- a/R/format_identifiers.R
+++ b/R/format_identifiers.R
@@ -1,52 +1,79 @@
 
 
-as_hashuri <- function(x){
-  # Named Info, https://tools.ietf.org/html/rfc6920
-  if(grepl("^ni://", x))
-    return( from_ni(x) )
-  
-  # magnet URI
-  if(grepl("^magnet:\\?xt=urn:", x))
-    return(from_magnet(x))
-  
-  # SSB
-  if(grepl("^\\&", x))
-    return(from_ssb(x))
-  
-  ## Subresource registry
-  if(grepl(paste0(algo_regex, "-", base64_regex), x))
-    return(from_subresource_registry(x))
-  
-}
+
+as_hashuri <- function(id){
+  vapply(id, 
+         function(x){
+           switch(id_format(x),
+           hashuri = x,
+           magnet = from_magnet(x),
+           sri = from_sri(x),
+           ssb = from_ssb(x),
+           ni = from_ni(x),
+           NA_character_)
+         },
+         character(1L),
+         USE.NAMES = FALSE)
+         
+  }
+
+
 
 algo_regex <- "(sha[0-9]{1,3}|md5)"
 base64_regex <- "((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?)"
 hex_regex <- "((0x|0X)?[a-fA-F0-9]+)"
+hashuri_regex <- paste0("^hash://", algo_regex, hex_regex)
+magnet_regex <- paste0("^magnet:\\?xt=urn:", algo_regex, ":", hex_regex)
+sri_regex <- paste0(algo_regex, "-", base64_regex)
+ssb_regex <- paste0("\\&", base64_regex, "\\.", algo_regex)
+ni_regex <- paste0("^ni:///", algo_regex,  ";", base64_regex)
 
-#' x <- "sha256-lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc="
-from_subresource_registry <- function(x){
-  hash <- gsub(paste0(algo_regex, "-", base64_regex), "\\2", x)
-  algo <- gsub(paste0(algo_regex, "-", base64_regex), "\\1", x)
+
+id_format <- function(x){
+  formats <- c("hashuri", "magnet", "sri", "ssb", "ni")
+  matches <- vapply(formats, 
+         function(type) is_hash(x, type),
+         logical(1L))
+  
+  if(!any(matches)) return(NA_character_)
+  
+  formats[matches]
+}
+
+is_hash <- function(x, type = c("hashuri", "magnet", "sri", "ssb", "ni")){
+  type <- match.arg(type)
+  pattern <- switch(type,
+                    hashuri = hashuri_regex,
+                    magnet = magnet_regex,
+                    sri = sri_regex,
+                    ssb = ssb_regex,
+                    ni = ni_regex,
+                    NA)
+  grepl(pattern, x)
+}
+
+
+# sri <- "sha256-lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc="
+from_sri <- function(x){
+  hash <- gsub(sri_regex, "\\2", x)
+  algo <- gsub(sri_regex, "\\1", x)
   hex <- paste0(openssl::base64_decode(hash), collapse = "")
   paste0("hash://", algo, "/", hex)
   
 }
 
-#' x <- "&lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc=.sha256"
+# ssb <- "&lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc=.sha256"
 from_ssb <- function(x){
-  
-  pattern <- paste0("\\&", base64_regex, "\\.", algo_regex)
-  hash <- gsub(pattern, "\\1", x)
-  algo <- gsub(pattern, "\\2", x)
+  hash <- gsub(ssb_regex, "\\1", x)
+  algo <- gsub(ssb_regex, "\\2", x)
   hex <- paste0(openssl::base64_decode(hash), collapse = "")
   paste0("hash://", algo, "/", hex)
   
 }
 
-#'   x <- "ni:///sha256;lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc"
+## note that named info doesn't have the trailing '='
+#   ni <- "ni:///sha256;lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc"
 from_ni <- function(x){
-  
-  #pattern <- paste0("^ni:///", algo_regex,  ";", base64_regex)
   
   hash <-  gsub(paste0("^ni:///([a-zA-Z0-9]+);", base64_regex), "\\2", x)
   algo <- gsub(paste0("^ni:///", algo_regex,  ";", hash), "\\1", x)
@@ -55,12 +82,10 @@ from_ni <- function(x){
 
 }
 
-#' x <- "magnet:?xt=urn:sha256:9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37"
+# magnet <- "magnet:?xt=urn:sha256:9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37"
 from_magnet <- function(x){
-  
-  pattern <- paste0("^magnet:\\?xt=urn:", algo_regex, ":", hex_regex)
-  algo <- gsub(pattern, "\\1", x)
-  hex <-  gsub(pattern, "\\2", x)
+  algo <- gsub(magnet_regex, "\\1", x)
+  hex <-  gsub(magnet_regex, "\\2", x)
   paste0("hash://", algo, "/", hex)
   
   

--- a/R/format_identifiers.R
+++ b/R/format_identifiers.R
@@ -14,9 +14,26 @@ as_hashuri <- function(id){
          },
          character(1L),
          USE.NAMES = FALSE)
-         
   }
 
+
+
+
+
+## SRI is a nice concise format that is useful for storage
+as_sri <- function(x) {
+  if(!grepl("sha256", x)) return(NA_character_)
+  y <- as_hashuri(x)
+  paste0("sha256-", hex_to_base64(strip_prefix(y)))
+}
+## Note we cannot simply `base64_encode(hex)`, since that treats hex string as if it were 
+## text and not raw bits.  We must convert it to raw bits like so: 
+## https://stackoverflow.com/questions/29251934/how-to-convert-a-hex-string-to-text-in-r
+hex_to_base64 <- function(s){
+  bits <- sapply(seq(1, nchar(s), by=2), function(x) substr(s, x, x+1))
+  raw <- as.raw(strtoi(bits, 16L))
+  openssl::base64_encode(raw)
+}
 
 
 algo_regex <- "(sha[0-9]{1,3}|md5)"

--- a/R/hash-archive.R
+++ b/R/hash-archive.R
@@ -54,13 +54,17 @@ hash_archive_api <- function(query, endpoint, host = "https://hash-archive.org")
 format_hashachiveorg <- function(x) {
   hash <- openssl::base64_decode(sub("^sha256-", "", x$hashes[[3]]))
   identifier <- add_prefix(paste0(as.character(hash), collapse = ""))
-  list(
-    identifier = identifier,
-    source = x$url,
-    date = .POSIXct(x$timestamp, tz = "UTC")
-  )
+  
+  registry_entry(identifier, 
+                 x$url,
+                 date = .POSIXct(x$timestamp, tz = "UTC"), 
+                 md5 = x$hashes[[1]],
+                 sha1 = x$hashes[[2]],
+                 sha256 = x$hashes[[3]],
+                 sha384 = x$hashes[[4]],
+                 sha512 = x$hashes[[5]])
+  
   ## Note that hash-archive.org also provides:
-  ## (1) type, (2) status, and other hash-flavors
-  ## We do not return these
+  ## (1) type, (2) status (3) size
 }
 

--- a/R/query.R
+++ b/R/query.R
@@ -17,11 +17,12 @@
 #' }
 #'
 query <- function(uri, registries = default_registries(), ...) {
-
-  if(is_content_id(uri)){
-    query_sources(uri, registries = registries, ...)
-  } else {
+  
+  
+  if(is_url(uri)){
     query_history(uri, registries = registries, ...)
+  } else {
+    query_sources(uri, registries = registries, ...)
   }
     
 }

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -22,7 +22,9 @@
 #' }
 #'
 retrieve <- function(id, dir = content_dir()) {
-  if (!is_content_id(id)){ 
+  
+  id <- as_hashuri(id)
+  if(is.na(id)){
     stop(paste(id, "is not a recognized content uri"), call. = FALSE)
   }
   

--- a/R/software-heritage.R
+++ b/R/software-heritage.R
@@ -20,6 +20,12 @@
 #' }
 #' 
 sources_swh <- function(id, host = "https://archive.softwareheritage.org", ...){
+  
+  id <- as_hashuri(id)
+  if(is.na(id)){
+    warning(paste("id", id, "not recognized as a valid identifier"), call. = FALSE)
+    return( null_query() )
+  }
 
   endpoint <- "/api/1/content/sha256:"
   hash <- strip_prefix(id)

--- a/R/software-heritage.R
+++ b/R/software-heritage.R
@@ -132,8 +132,6 @@ retrieve_swh <- function(id, host = "https://archive.softwareheritage.org"){
 
 
 null_query <- function(){
-  data.frame(identifer = as.character(NA), 
-             source = as.character(NA), 
-             date = as.POSIXct(NA))[0,]
+  registry_entry()[0,]
 }
 

--- a/R/tsv_registry.R
+++ b/R/tsv_registry.R
@@ -1,11 +1,17 @@
 ## A tab-seperated-values backed registry
 
+as_sri <- function(x) {
+  if(!grepl("sha256", x)) return(NA_character_)
+  y <- as_hashuri(x)
+  paste0("sha256-", openssl::base64_encode(strip_prefix(y)))
+  }
 
-registry_spec <- "ccT"
+registry_spec <- "ccTccccc"
+## use base64 encoding for more space-efficient storage
 registry_entry <- function(id = NA_character_, source = NA_character_, date = Sys.time(),
                            md5 = NA_character_, 
                            sha1 = NA_character_, 
-                           sha256 = strip_prefix(id), 
+                           sha256 = as_sri(id), 
                            sha384 = NA_character_, 
                            sha512 = NA_character_){
   
@@ -42,7 +48,6 @@ sources_tsv <- function(id, dir = content_dir()) {
   }
   
 
-  registry_entry()
   df <- readr::read_tsv(tsv_init(dir), col_types = registry_spec)
   df[df$identifier == id, ] ## base R version
   

--- a/R/tsv_registry.R
+++ b/R/tsv_registry.R
@@ -1,10 +1,5 @@
 ## A tab-seperated-values backed registry
 
-as_sri <- function(x) {
-  if(!grepl("sha256", x)) return(NA_character_)
-  y <- as_hashuri(x)
-  paste0("sha256-", openssl::base64_encode(strip_prefix(y)))
-  }
 
 registry_spec <- "ccTccccc"
 ## use base64 encoding for more space-efficient storage

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,7 +30,6 @@ download_resource <- function(x) {
 ## These should be much more general!
 add_prefix <- function(x) paste0("hash://sha256/", x)
 strip_prefix <- function(x) gsub("^hash://sha256/", "", x)
-is_content_id <- function(x) grepl("^hash://sha256/", x)
 is_url <- function(x) grepl("^((http|ftp)s?|sftp)://", x)
 
 

--- a/tests/testthat/test-format_identifiers.R
+++ b/tests/testthat/test-format_identifiers.R
@@ -1,0 +1,51 @@
+context("identifier formats")
+
+magnet <- "magnet:?xt=urn:sha256:9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37"
+sri <- "sha256-lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc="
+ssb <- "&lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc=.sha256"
+ni <- "ni:///sha256;lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc"
+hashuri <- "hash://sha256/9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37"
+
+
+test_that("we can convert other formats to hash uri", {
+
+    ids <- c(magnet, sri, ssb, ni, hashuri)
+    out <- as_hashuri(ids)
+  
+    matching <- vapply(out, function(x) 
+      # Note: ni omits the optional base64 '=' ending character, corresponding to the '7e37'
+      grepl("hash://sha256/9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff64628",
+            x), logical(1L))
+    expect_true(all(matching))
+  
+
+})
+
+
+
+test_that("we can correctly recognize types without false ids", {
+  
+  expect_true(is_hash(ssb, "ssb"))
+  expect_true(is_hash(ni, "ni"))
+  expect_true(is_hash(sri, "sri"))
+  expect_true(is_hash(magnet, "magnet"))
+  expect_true(is_hash(hashuri, "hashuri"))
+  
+  
+  expect_false(is_hash(ni, "ssb"))
+  expect_false(is_hash(sri, "ni"))
+  expect_false(is_hash(ssb, "sri"))
+  expect_false(is_hash(hashuri, "magnet"))
+  expect_false(is_hash(magnet, "hashuri"))
+
+  expect_false(is_hash("https://example.com"))
+
+    
+  expect_true(is.na(as_hashuri("http://example.com")))
+  
+  
+})
+
+
+
+

--- a/tests/testthat/test-register-query.R
+++ b/tests/testthat/test-register-query.R
@@ -30,7 +30,7 @@ test_that("We can register a URL in the local registry", {
     "https://zenodo.org/record/3678928/files/vostok.icecore.co2",
     registries = local)
   expect_is(x, "character")
-  expect_true(is_content_id(x))
+  expect_true(is_hash(x, "hashuri"))
 })
 
 


### PR DESCRIPTION
This adds preliminary support for multiple identifier formats (#1) in functions taking an identifier as an argument.  `hash://sha256/xx` format remains the internal format, this is just using regex's and base64 decoding to recognize and convert other identifier formats (SSB, SRI, magnet, and NI).  

This also starts setting up support for storing multiple hash types in the local tsv registry, but currently these are just placeholders until we can efficiently compute other hashes (#38).  Even then, `store()` will remain `sha256`-based, these additional hashes will really just be for the local registry. (these multiple hash types are already understood by hash-archive.org: md5, sha1, sha256, sha384, sha512).

  