### PR TITLE
Filter query_sources()

### DIFF
--- a/R/hash-archive.R
+++ b/R/hash-archive.R
@@ -18,7 +18,7 @@ register_ha <- function(url, host = "https://hash-archive.org") {
   if(grepl("^ftp", url)){
     warning(paste("hash-archive.org cannot retreive data from ftp...\n",
                   "skipping", url))
-    return(as.character(NA))
+    return(NA_character_)
   }
   
   endpoint <- "api/enqueue"
@@ -52,12 +52,15 @@ hash_archive_api <- function(query, endpoint, host = "https://hash-archive.org")
 ## a formatter for data returned by hash-archive.org
 #' @importFrom openssl base64_decode
 format_hashachiveorg <- function(x) {
+  
   hash <- openssl::base64_decode(sub("^sha256-", "", x$hashes[[3]]))
   identifier <- add_prefix(paste0(as.character(hash), collapse = ""))
   
   registry_entry(identifier, 
                  x$url,
                  date = .POSIXct(x$timestamp, tz = "UTC"), 
+                 size = x$length,
+                 status = x$status,
                  md5 = x$hashes[[1]],
                  sha1 = x$hashes[[2]],
                  sha256 = x$hashes[[3]],

--- a/R/pin.R
+++ b/R/pin.R
@@ -34,10 +34,7 @@
 pin <- function(url, verify = TRUE, dir = content_dir()) {
   
   if(!verify){
-    
     unverified_resolver(url, dir)
-    
-  
   }
   
   # Have hash-archive.org compute the identifier. Its high bandwidth

--- a/R/query_sources.R
+++ b/R/query_sources.R
@@ -49,7 +49,10 @@ query_sources <- function(id, registries = default_registries(), ...){
   store_out <- do.call(rbind, store_out)
   
   
-  rbind(ha_out, store_out, reg_out)
+  ## format return to show only most recent
+  out <- rbind(ha_out, store_out, reg_out)
+  out
+  #filter_sources(out, registries)
   
   
 }

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -46,7 +46,13 @@ resolve <- function(id,
                     ...) {
   
   prefer = c("local", "remote")
-  df <- query(id, registries, ...)
+  df <- query_sources(id, registries, cols=c("identifier", "source", "date"), ...)
+  
+  if(is.null(df)){
+    warning(paste("No sources found for", id))
+    return(NA_character_)
+  }
+  
   ## rev() so higher priority -> higher number (we sort descending)
   df$registry <- factor(NA, levels = rev(prefer))
 
@@ -79,7 +85,6 @@ attempt_source <- function(entries, verify = TRUE, verify_local = FALSE) {
     return(NULL)
   }
 
-  ## We only care about unique sources!  should collapse the list
   entries <- unique(entries[c("identifier", "source")])
 
   for (i in 1:N) {

--- a/R/tsv_registry.R
+++ b/R/tsv_registry.R
@@ -6,9 +6,13 @@ as_sri <- function(x) {
   paste0("sha256-", openssl::base64_encode(strip_prefix(y)))
   }
 
-registry_spec <- "ccTccccc"
+registry_spec <- "ccTiiccccc"
 ## use base64 encoding for more space-efficient storage
-registry_entry <- function(id = NA_character_, source = NA_character_, date = Sys.time(),
+registry_entry <- function(id = NA_character_, 
+                           source = NA_character_, 
+                           date = Sys.time(),
+                           size = fs::file_size(source, FALSE),
+                           status = 200L,
                            md5 = NA_character_, 
                            sha1 = NA_character_, 
                            sha256 = as_sri(id), 
@@ -16,7 +20,16 @@ registry_entry <- function(id = NA_character_, source = NA_character_, date = Sy
                            sha512 = NA_character_){
   
   
-  data.frame(identifier = id, source = source, date = date,
+  if(is.na(id)){
+    status <- 404L
+    size <- NA_integer_
+  }
+  
+  data.frame(identifier = id, 
+             source = source, 
+             date = date, 
+             size = as.integer(size), 
+             status = status,
              md5 = md5, sha1 = sha1, sha256 = sha256, sha384 = sha384, sha512 = sha512,
              stringsAsFactors = FALSE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -80,39 +80,3 @@ stream_binary <- function(input, dest, n = 1e5){
 
 
 
-most_recent_sources <- function(df){
-  
-  reg <- df[order(df$date, decreasing = TRUE),]
-  unique_sources <- unique(reg$source)
-  
-  out <- registry_entry(id = reg$identifier[[1]], 
-                        source = unique_sources, 
-                        date = as.POSIXct(NA))
-  
-  for(i in seq_along(unique_sources)){
-    out[i,] <- reg[reg$source == unique_sources[i], ][1,]
-  }
-  out
-}
-
-filter_sources <- function(df, registries = default_registries(), 
-                           cols = c("source, date")){
-  id_sources <- most_recent_sources(df)
-  
-  ## Now, check history for all these URLs and see if the content is current 
-  url_sources <- id_sources$source[is_url(id_sources$source)]
-  history <- do.call(rbind, lapply(url_sources, query_history, registries = registries))
-  
-  
-  recent_history <- most_recent_sources(history)
-  
-  out <- most_recent_sources(rbind(recent_history, id_sources))
-   
-  
-  out$status[out$status >= 400L] <- NA_integer_
-  out <- out[!is.na(out$status), ]
-  out[cols]
-  
-}
-
-

--- a/man/query_sources.Rd
+++ b/man/query_sources.Rd
@@ -4,12 +4,19 @@
 \alias{query_sources}
 \title{List all known URL sources for a given Content URI}
 \usage{
-query_sources(id, registries = default_registries(), ...)
+query_sources(
+  id,
+  registries = default_registries(),
+  cols = c("source", "date"),
+  ...
+)
 }
 \arguments{
 \item{id}{a content identifier}
 
 \item{registries}{list of registries at which to register the URL}
+
+\item{cols}{names of columns to keep. Default are \code{source} and \code{date}.  See details.}
 
 \item{...}{additional arguments}
 }
@@ -19,6 +26,10 @@ a local path (including the local store) have contained the corresponding conten
 }
 \description{
 List all known URL sources for a given Content URI
+}
+\details{
+possible columns are (in order): \code{identifier}, \code{source}, \code{date},
+\code{size}, \code{status}, \code{md5}, \code{sha1}, \code{sha256}, \code{sha384}, \code{sha512}
 }
 \examples{
 \donttest{


### PR DESCRIPTION
Implement a filter on query_sources() to avoid listing a single source repeatedly for all dates. See #36 