### PR TITLE
quick patch: swh queries were not included by default

### DIFF
--- a/R/query_history.R
+++ b/R/query_history.R
@@ -27,8 +27,8 @@ query_history <- function(url, registries = default_registries(), ...){
   reg_out <- NULL
 
   ## Remote host registries  (hash-archive.org type only)
-  if (any(is_url(registries))){
-    remote <- registries[is_url(registries)]
+  if (any(grepl("hash-archive.org", registries))){
+    remote <- registries[grepl("hash-archive.org", registries)]  
     ha_out <- lapply(remote, function(host) history_ha(url, host = host))
     ha_out <- do.call(rbind, ha_out)
   }

--- a/R/query_sources.R
+++ b/R/query_sources.R
@@ -57,7 +57,7 @@ query_sources <- function(id,
   
   
   ## format return to show only most recent
-  out <- rbind(ha_out, store_out, reg_out)
+  out <- rbind(ha_out, store_out, reg_out, swh_out)
   filter_sources(out, registries, cols)
 
 }

--- a/R/register.R
+++ b/R/register.R
@@ -26,7 +26,7 @@ register_ <- function(url, registries = default_registries(), ...) {
   local_out <- NULL
   remote_out <- NULL
 
-  if (any(grepl("^https://hash-archive.org", registries))) {
+  if (any(grepl("hash-archive.org", registries))) {
     remote_out <- register_ha(url)
   }
 
@@ -70,6 +70,7 @@ default_registries <- function() {
       "CONTENTURI_REGISTRIES",
       paste(content_dir(),
         "https://hash-archive.org",
+        "https://archive.softwareheritage.org",
         sep = ", "
       )
     ),

--- a/R/software-heritage.R
+++ b/R/software-heritage.R
@@ -37,10 +37,10 @@ sources_swh <- function(id, host = "https://archive.softwareheritage.org", ...){
   if(httr::status_code(response) != 200)
    return( null_query() )
   
-  data.frame(identifer = id, 
-             source = result$data_url,
-             date = Sys.time()
-            )
+  registry_entry(id, 
+                 source = result$data_url,
+                 date = Sys.time()
+                 )
   
   
 }


### PR DESCRIPTION
this adds software heritage into the default registries list and includes queries against it.

This makes examples like https://github.com/cboettig/contentid/issues/19#issuecomment-605299089 actually work.  