### PR TITLE
trivial examples of querying static http content stores

### DIFF
--- a/R/format_identifiers.R
+++ b/R/format_identifiers.R
@@ -89,6 +89,7 @@ from_ssb <- function(x){
 }
 
 ## note that named info doesn't have the trailing '='
+## argh this should be base64url encoded (that's URL-encoded!), and without trailing `=`, by spec
 #   ni <- "ni:///sha256;lBIyWDHasiruvdZ0tutTumt73QS7maTbsh3f9kYofjc"
 from_ni <- function(x){
   

--- a/R/store.R
+++ b/R/store.R
@@ -61,8 +61,8 @@ store <- function(x, dir = content_dir()) {
 content_based_location <- function(hash, dir = content_dir()) {
   ## use 2-level nesting
   hash <- strip_prefix(hash)
-  sub1 <- gsub("^(\\w{2}).*", "\\1", hash)
-  sub2 <- gsub("^(\\w{2})(\\w{2}).*", "\\2", hash)
+  sub1 <- substr(hash, 1, 2)
+  sub2 <- substr(hash, 3, 4)
   base <- fs::path_abs(fs::path("data", sub1, sub2), start = dir)
   fs::dir_create(base)
   path <- fs::path(base, hash)

--- a/inst/examples/deeplinker.R
+++ b/inst/examples/deeplinker.R
@@ -1,0 +1,51 @@
+
+## Access content from a simple content-based store like "data.carlboettiger.info" or "deeplinker.bio"
+## This provides trivial implementations for query_sources() and `retreive()` for such stores
+## These methods require only `httr` and base R functions, no `contentid` functions.
+
+## generic
+query_sources.httpstore <- function(id, host, path_fn = identity){
+  query <- paste(host, path_fn(id), sep = "/")  
+  resp <- httr::HEAD(query)
+  code <- httr::status_code(resp)
+  if(code >= 400L) return(NA_character_)
+
+  # contentid:::registry_entry(id = id, source = query)
+  
+  data.frame(identifier = id, source = query, status = code, date = Sys.time())
+}
+
+retrieve.httpstore <- function(id, host, path_fn){
+  sources_httpstore(id, host, path_fn)$source
+}
+
+
+sources_boettiger <- function(id){
+  hash_path <- function(id){
+    x <- strip_prefix(id)
+    paste(substr(x, 1, 2),
+          substr(x, 3, 4),
+          x, sep = "/")
+    
+  }
+  query_sources.httpstore(id, host = "https://data.carlboettiger.info/data", path_fn = hash_path)
+}
+
+sources_deeplinker <- function(id){ 
+  strip_prefix <- sub("^hash://sha256/", "", x)
+  query_sources.httpstore(id, host = "https://deeplinker.bio", path_fn = strip_prefix)
+}
+
+
+## examples:
+
+id <- "hash://sha256/496f800620dced0b1da54cfde869055c87d8199b192e4e92305308f0d1253f29"
+sources_boettiger(id)
+
+id2 <- "hash://sha256/fcc80ef5d19f6ae67a9966551bc8229d8113d9bbc4f6554e798bb1cdc071ab64"
+sources_deeplinker(id2)
+
+## unregistered content returns NA:
+sources_boettiger(id2)
+
+## Because these stores are read-only, we cannot register.httpstore() or store.httpstore)

--- a/vignettes/alternatives.Rmd
+++ b/vignettes/alternatives.Rmd
@@ -1,0 +1,27 @@
+---
+title: "Comparison of contentid to common alternatives"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Comparison of contentid to common alternatives}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(contentid)
+```
+
+- DOIs
+- IPFS
+- `pins`
+
+
+
+

--- a/vignettes/software-heritage.Rmd
+++ b/vignettes/software-heritage.Rmd
@@ -1,0 +1,19 @@
+---
+title: "Using Content Identifiers with the Software Heritage Archive"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Using Content Identifiers with the Software Heritage Archive}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(contentid)
+```


### PR DESCRIPTION
e.g. `query_sources()` and `retrieve()` methods for https://data.carlboettiger.info and https://deeplinker.bio.  

(Note, this doesn't yet include doing anything with the deeplinker *registry* / provenance info, this just interacts directly with the store as noted in https://gist.github.com/cboettig/cb8d6ba61a8aa56304e6bfb8ce801198#gistcomment-3203125.  