### PR TITLE
bugfix

### DIFF
--- a/R/query_sources.R
+++ b/R/query_sources.R
@@ -103,6 +103,7 @@ filter_sources <- function(df,
 most_recent_sources <- function(df){
   
   if(is.null(df)) return(df)
+  if(nrow(df) == 0) return(df)
   
   reg <- df[order(df$date, decreasing = TRUE),]
   unique_sources <- unique(reg$source)

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -10,7 +10,8 @@
 #' @param verify logical, default [TRUE]. Should we verify that
 #'  content matches the requested hash?
 #' @param store logical, should we add remotely downloaded copy to the local store?
-#' @param dir path to the local store directory
+#' @param dir path to the local store directory. Defaults to first local registry given to
+#'  the `registries` argument. 
 #' @inheritParams query
 #' @details Local storage
 #'  is checked first as it will allow us to bypass downloading content
@@ -36,18 +37,18 @@ resolve <- function(id,
                     registries = default_registries(),
                     verify = TRUE,
                     store = FALSE,
-                    dir = content_dir(),
+                    dir = registries[dir.exists(registries)][[1]],
                     ...) {
   
   df <- query_sources(id, registries, cols=c("identifier", "source", "date"), ...)
   
-  if(is.null(df)){
+  if(is.null(df) || nrow(df) == 0){
     warning(paste("No sources found for", id))
     return(NA_character_)
   }
   
   path <- attempt_source(df, verify = verify)
-
+  
   if(store){
     store(path, dir = dir)
     path <- retrieve(id, dir = dir) 

--- a/inst/examples/dataone-checkpointing.R
+++ b/inst/examples/dataone-checkpointing.R
@@ -10,7 +10,13 @@ library(parallel)
 library(purrr)
 library(httr)
 
-ref <- contentid::resolve("hash://sha256/c7b8f1033213f092df630e9fc26cd6d941f2002c95ab829f0180903bc0cdcd50", store=TRUE)
+
+#########################
+
+### SKIP this block, start with pre-filtered version below ##
+
+## loads registered snapshot (see dataone.R)
+ref <- contentid::resolve("hash://sha256/598032f108d602a8ad9d1031a2bdc4bca1d5dca468981fa29592e1660c8f4883", registries = "/zpool/content-store")
 dataone <- vroom::vroom(ref, col_select = c(contentURL, baseURL)) %>% filter(!grepl("dryad", contentURL))
 
 ## Discover and prune failing domains
@@ -18,16 +24,31 @@ baseURLs <- dataone %>% select(baseURL) %>% distinct()
 resp <- map(baseURLs[[1]], purrr::safely(httr::GET, list(status_code = -1)))
 err_msg <- as.character(map(map(resp, "error"), "message"))
 problems <- data.frame(domain = baseURLs[[1]], err_msg, stringsAsFactors = FALSE) %>% filter(!grepl("^NULL", err_msg))
+dataone_good <- dataone %>% anti_join(select(problems, domain), by = c("baseURL" = "domain"))  %>% select(contentURL)
+#sum(grepl("usherbrooke", dataone$contentURL)) ## expect 0
 
 
-dataone <- dataone %>% anti_join(select(problems, domain), by = c("baseURL" = "domain")) 
-#sum(grepl("usherbrooke", dataone$contentURL))
+## Store clean snapshot: only the good contentURLs 
+readr::write_tsv(dataone_good, "dataone_good.tsv.gz")
+contentid::store("dataone_good.tsv.gz", "/zpool/content-store")
 
-rm(bases); rm(err_msg); rm(domain); rm(err); rm(problems); rm(resp); gc()
+rm(baseURLS); rm(resp); rm(err_msg); rm(problems);  gc()
 
-## All dryad is 404!!
+######################
+library(contentid)
+library(vroom)
+library(dplyr)
+library(parallel)
+library(purrr)
+library(httr)
+
+## Start with registered contentURL list and omit the ones already in registry:
+
+ref2 <- contentid::resolve("hash://sha256/2b961ccaac6068ed42ea34c1968d237af1b81cd16511ee0848e3ed5f0e573656", registries = "/zpool/content-store")
+dataone <- vroom::vroom(ref2, col_select = c(contentURL))
 
 done <- vroom::vroom("/zpool/content-store/data/registry.tsv.gz")
+
 contentURLs <- dplyr::anti_join(dataone, done, by = c(contentURL = "source"))[[1]]
 rm(dataone); rm(done); gc()
 
@@ -37,12 +58,16 @@ contentURLs <- contentURLs[!bad]
 
 p1 <- dplyr::progress_estimated(length(contentURLs))
 register_local_progress <- function(x){
-  #p1$tick()$print()
-  tryCatch(register(x,
+  p1$tick()
+  if(p1$i %% 5000 == 0) gc() # not clear that this helps any...
+  
+  tryCatch(
+    register(x,
                     "/zpool/content-store",
                     algos = c("md5","sha1","sha256")),
            error = function(e) NA_character_,
            finally = NA_character_)
+  
 }
 
 ### May run out of memory

--- a/inst/examples/dataone.R
+++ b/inst/examples/dataone.R
@@ -65,22 +65,12 @@ dataone <-
   mutate(contentURL = paste0(baseURL, 
                              "/v2/object/", xml2::url_escape(identifier))) 
 
-
-
-# contentid::store("dataone.tsv.gz", "/zpool/content-store/")
-# id: "hash://sha256/f445beccc9c13d03580ee689bbe25ac2dccf52a179ad7fa0b02ade53f772c66e" stored
-
-
-## inspect 
-# dataone %>% count()
-# dataone %>% summarise(total = sum(size))
-
 ## let's do the small ones first.
 dataone <- dataone %>% arrange(size)
 readr::write_tsv(dataone, "dataone.tsv.gz")
                                                               
-contentid::store("dataone.tsv.gz")                          
-# "hash://sha256/c7b8f1033213f092df630e9fc26cd6d941f2002c95ab829f0180903bc0cdcd50"
+contentid::store("dataone.tsv.gz", "/zpool/content-store/")
+
 
 #######################################                                 
 ## start clean

--- a/man/pin.Rd
+++ b/man/pin.Rd
@@ -12,7 +12,8 @@ pin(url, verify = TRUE, dir = content_dir())
 \item{verify}{logical, default TRUE. Should we verify the content identifier (SHA-256 hash)
 of content at the URL before we look for a local cache?}
 
-\item{dir}{path to the local store directory}
+\item{dir}{path to the local store directory. Defaults to first local registry given to
+the \code{registries} argument.}
 }
 \description{
 This will download the requested object to a local cache and return the local path of the

--- a/man/resolve.Rd
+++ b/man/resolve.Rd
@@ -9,7 +9,7 @@ resolve(
   registries = default_registries(),
   verify = TRUE,
   store = FALSE,
-  dir = content_dir(),
+  dir = registries[dir.exists(registries)][[1]],
   ...
 )
 }
@@ -23,7 +23,8 @@ content matches the requested hash?}
 
 \item{store}{logical, should we add remotely downloaded copy to the local store?}
 
-\item{dir}{path to the local store directory}
+\item{dir}{path to the local store directory. Defaults to first local registry given to
+the \code{registries} argument.}
 
 \item{...}{additional arguments}
 }


### PR DESCRIPTION
`resolve` takes both a `registries` argument and separately, a `dir` argument that is just used if `store=TRUE`.  makes more sense for the store `dir` to inherit from any local registry given in registries than to default to the default content_dir