### PR TITLE
Don't pre-open connections

### DIFF
--- a/R/content_id.R
+++ b/R/content_id.R
@@ -1,7 +1,6 @@
 
 #' Generate a content uri for a local file
 #' @param file path to the file, URL, or a [base::file] connection
-#' @param open The mode to open text, see details for `Mode` in [base::file].
 #' @param raw Logical, should compressed data be left as compressed binary?
 #' @param algos Which algorithms should we compute contentid for? Default "sha256",
 #' see details.
@@ -33,13 +32,12 @@
 #' 
 content_id <- function(file, 
                        algos = default_algos(),
-                       open = "", 
                        raw = TRUE
                        ){
   
   # cannot vapply a connection
   if(inherits(file, "connection")){ 
-    out <- content_id_(file, algos = algos, open = open, raw = raw)
+    out <- content_id_(file, algos = algos, raw = raw)
     
   } else {
     
@@ -47,7 +45,6 @@ content_id <- function(file,
                   content_id_, 
                   character(length(algos)),
                   algos = algos,
-                  open = open, 
                   raw = raw) 
   }
   
@@ -63,7 +60,6 @@ content_id <- function(file,
 
 content_id_ <- function(file,
                         algos = default_algos(),
-                        open = "", 
                         raw = TRUE
                         ) {
   
@@ -73,7 +69,7 @@ content_id_ <- function(file,
     return(rep(NA_character_, length(algos)))
   }
   
-  con <- stream_connection(file, open = open, raw = raw)
+  con <- stream_connection(file, raw = raw)
   
   if(!is_valid.connection(con)){ 
     paste(file, "is not a valid connection", call.=FALSE)

--- a/R/store.R
+++ b/R/store.R
@@ -34,8 +34,7 @@ store <- function(x, dir = content_dir()) {
   
   ## Handle paths, connections, urls. assure download only once.
   con <- stream_connection(x, download = TRUE)
-  on.exit(close(con))
-  
+
   ## Compute the sha256 content identifier
   id <- content_id(con, algos = "sha256")[["sha256"]]
   

--- a/R/store.R
+++ b/R/store.R
@@ -34,6 +34,7 @@ store <- function(x, dir = content_dir()) {
   
   ## Handle paths, connections, urls. assure download only once.
   con <- stream_connection(x, download = TRUE)
+  filepath <- local_path(con)
 
   ## Compute the sha256 content identifier
   id <- content_id(con, algos = "sha256")[["sha256"]]
@@ -45,7 +46,7 @@ store <- function(x, dir = content_dir()) {
   ## Here we actually copy the data into the local store
   ## Using paths and file.copy() is faster than streaming
   if(!fs::file_exists(dest))
-    fs::file_copy(local_path(con), dest)
+    fs::file_copy(filepath, dest)
   
   ## Alternately, for an open connection, but slower
   # stream_binary(con, dest)

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,7 +34,7 @@ is_url <- function(x) grepl("^((http|ftp)s?|sftp)://", x)
 
 
 
-stream_connection <- function(file, download = FALSE, open = "rb", raw = TRUE){
+stream_connection <- function(file, download = FALSE, raw = TRUE){
   
   if (inherits(file, "connection")) {
     return(file)
@@ -48,10 +48,7 @@ stream_connection <- function(file, download = FALSE, open = "rb", raw = TRUE){
   
   ## Path Name
   if (is.character(file)) {
-    file <- file(file, open = open, raw = raw) 
-    ## cannot close on exit, but we register a finalizer?
-    env <-  parent.env(environment())
-    reg.finalizer(env, function(env) close(file))
+    file <- file(file, raw = raw) 
   }
   if (!inherits(file, "connection")) 
     stop("'file' must be a character string or connection")
@@ -90,10 +87,10 @@ stream_binary <- function(input, dest, n = 1e5){
     on.exit(close(input))
   }
   output <- file(dest, "wb")
+  on.exit(close(output), add = TRUE)
   while(length(obj <- readBin(input, "raw", n = n))){
     writeBin(obj, output, useBytes = TRUE)
   } 
-  close(output)
   dest
 }
 

--- a/man/content_id.Rd
+++ b/man/content_id.Rd
@@ -4,15 +4,13 @@
 \alias{content_id}
 \title{Generate a content uri for a local file}
 \usage{
-content_id(file, algos = default_algos(), open = "", raw = TRUE)
+content_id(file, algos = default_algos(), raw = TRUE)
 }
 \arguments{
 \item{file}{path to the file, URL, or a \link[base:file]{base::file} connection}
 
 \item{algos}{Which algorithms should we compute contentid for? Default "sha256",
 see details.}
-
-\item{open}{The mode to open text, see details for \code{Mode} in \link[base:file]{base::file}.}
 
 \item{raw}{Logical, should compressed data be left as compressed binary?}
 }


### PR DESCRIPTION
You should let the function that consumes the data (e.g. `multihash` or `sha256`) handle opening and closing of the connection. 