### PR TITLE
Adds DataONE to the list of resolvable registries

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,2 @@
-This package was submitted to CRAN on 2020-09-25.
-Once it is accepted, delete this file and tag the release (commit 57bc20f).
+This package was submitted to CRAN on 2021-01-15.
+Once it is accepted, delete this file and tag the release (commit 041c7d1).

--- a/R/bagit.R
+++ b/R/bagit.R
@@ -64,7 +64,7 @@ bagit_manifest <- function(dir = content_dir()) {
 bagit_manifest_from_content_store <- function(dir = content_dir()){
   
   path <- fs::path_abs("manifest-sha256.txt", dir)
-  data_dir <- fs::path_abs("data", dir)
+  data_dir <- fs::path_abs("sha256", dir)
   fs::dir_create(data_dir)
   
   files <- fs::dir_ls(data_dir, recurse = TRUE, type = "file")

--- a/R/dataone_registry.R
+++ b/R/dataone_registry.R
@@ -1,23 +1,32 @@
 
 
-#' @examples \donttest{
-#' id <- paste0("hash://md5/e27c99a7f701dab97b7d09c467acf468")
-#' sources_dataone(id)
-#' }
-sources_dataone <- function(id, baseURL = "https://cn.dataone.org/cn/"){
+
+# @examples \donttest{
+# id <- paste0("hash://md5/e27c99a7f701dab97b7d09c467acf468")
+# sources_dataone(id)
+# }
+sources_dataone <- function(id, host = "https://cn.dataone.org/"){
   hash <- gsub("^hash://\\w+/", "", id)
-  query <- paste0(baseURL, "/v2/query/solr/","?q=checksum:",hash,
+  query <- paste0(host, "/cn/v2/query/solr/","?q=checksum:",hash,
                   "&fl=identifier,size,formatId,checksum,checksumAlgorithm,",
                   "replicaMN,dataUrl&rows=10&wt=json")
   resp <- httr::GET(query)
   out <- httr::content(resp)
-  sources <- lapply(out$response$docs, `[[`,"dataUrl")[[1]]
+  sources <- lapply(out$response$docs, `[[`,"dataUrl")
+  if(length(sources) == 0){
+    return(null_query())
+  } 
+  sources <- sources[[1]]
   size <- lapply(out$response$docs, `[[`,"size")[[1]]
-  
-  data.frame(id = id, source = sources, date = Sys.Date(), size = size)
+  out <- registry_entry(id, source = sources, date = Sys.time())
+
 }
 
-
+# @examples \donttest{
+# id <- paste0("hash://md5/e27c99a7f701dab97b7d09c467acf468")
+# sources_dataone(id)
+# }
+# 
 retrieve_dataone <- function(id, baseURL = "https://cn.dataone.org/cn/"){
   df <- sources_dataone(id, baseURL)
   df$source
@@ -26,8 +35,5 @@ retrieve_dataone <- function(id, baseURL = "https://cn.dataone.org/cn/"){
 ## We can also "register" an identifier at dataone by depositing the data object.
 ## This requires the `dataone` R package and an authentication token -- so
 ## rather beyond the scope of a small `contentid` package.
-register_dataone <- function(file){
-  
-}
 
 

--- a/R/default_registries.R
+++ b/R/default_registries.R
@@ -1,0 +1,44 @@
+
+#' default registries
+#'
+#' A helper function to conviently load the default registries
+#' @details This function is primarily useful to restrict the
+#' scope of [query_sources] or [register] to, e.g. either just the
+#' remote registry or just the local registry.  Note that a user
+#' can alter the registry on the fly by passing local paths and/or the
+#' URL (`https://hash-archive.org`) directly.
+#'
+#' @examples
+#' ## Both defaults
+#' default_registries()
+#'
+#' ## Only the fist one (local registry)
+#' default_registry()[1]
+#' \donttest{
+#' ## Alter the defaults with env var.
+#' ## here we set two local registries as the defaults
+#' Sys.setenv(CONTENTID_REGISTRIES = "store/, store2/")
+#' default_registries()
+#'
+#' Sys.unsetenv(CONTENTID_REGISTRIES)
+#' }
+#' @noRd
+# @export
+default_registries <- function() {
+  registries <- strsplit(
+    Sys.getenv(
+      "CONTENTID_REGISTRIES",
+      paste(
+        default_tsv(),                           ## local registry
+        "https://hash-archive.org",              ## Hash Archives
+        "https://archive.softwareheritage.org",  ## Only for query, not register
+        "https://cn.dataone.org",                ## Only for query, not register
+        content_dir(),                           ## Local stores
+        sep = ", "
+      )
+    ),
+    ", "
+  )[[1]]
+  
+  registries
+}

--- a/R/query_history.R
+++ b/R/query_history.R
@@ -36,6 +36,9 @@ query_history <- function(url, registries = default_registries(), ...){
   ha_out <- NULL
   tsv_out <- NULL
   lmdb_out <- NULL
+  
+  registries <- expand_registery_urls(registries)
+  
 
   ## Remote host registries  (hash-archive.org type only)
   if (any(grepl("hash-archive.org", registries))){

--- a/R/query_sources.R
+++ b/R/query_sources.R
@@ -165,8 +165,11 @@ most_recent_sources <- function(df){
 
 
 
-
-## could do more native implementation without the bagit-based i/o
-## This reflects that the local store is implicitly a registry
-sources_store <- bagit_query
+sources_store <- function(id, dir = content_dir()){
+  source = content_based_location(id, dir)
+  registry_entry(id = id, 
+                 source = source, 
+                 date = fs::file_info(source)$modification_time
+                 )
+}
 

--- a/R/query_sources.R
+++ b/R/query_sources.R
@@ -34,16 +34,19 @@ query_sources <- function(id,
   swh_out <- NULL
   dataone_out <- NULL
   
+  
+  registries <- expand_registery_urls(registries)
+  
   if(curl::has_internet()){
     ## Remote hash-archive.org type registries
-    if (any(grepl("hash-archive.org", registries))){
-      remote <- registries[grepl("hash-archive.org", registries)]
+    if (any(grepl("hash-archive", registries))){
+      remote <- registries[grepl("hash-archive", registries)]
       ha_out <- lapply(remote, function(host) sources_ha(id, host = host))
       ha_out <- do.call(rbind, ha_out)
     }
     
-    if (any(grepl("softwareheritage.org", registries))){
-      remote <- registries[grepl("softwareheritage.org", registries)]
+    if (any(grepl("softwareheritage", registries))){
+      remote <- registries[grepl("softwareheritage", registries)]
       ## Note: vectorization is unnecessary here. 
       ## error handling to avoid failure if SWH call fails
       swh_out <- tryCatch(
@@ -53,8 +56,8 @@ query_sources <- function(id,
         )
     }
     
-    if (any(grepl("dataone.org", registries))){
-      remote <- registries[grepl("dataone.org", registries)]
+    if (any(grepl("dataone", registries))){
+      remote <- registries[grepl("dataone", registries)]
       ## Note: vectorization is unnecessary here. 
       ## error handling to avoid failure if SWH call fails
       swh_out <- tryCatch(
@@ -63,7 +66,6 @@ query_sources <- function(id,
         finally = NULL
       )
     }
-    
   }
   
   ## Local, tsv-backed registries
@@ -93,6 +95,17 @@ query_sources <- function(id,
   filter_sources(out, registries, cols)
 
 }
+
+
+expand_registery_urls <- function(registries) {
+  
+  registries[grepl("^dataone$", registries)] <- "https://cn.dataone.org"
+  registries[grepl("^hash-archive$", registries)] <- "https://hash-archive.org"
+  registries[grepl("softwareheritage", registries)] <- "https://archive.softwareheritage.org"
+  registries
+  
+}
+
 
 
 filter_sources <- function(df, 

--- a/R/query_sources.R
+++ b/R/query_sources.R
@@ -32,6 +32,7 @@ query_sources <- function(id,
   lmdb_out <- NULL
   store_out <- NULL
   swh_out <- NULL
+  dataone_out <- NULL
   
   if(curl::has_internet()){
     ## Remote hash-archive.org type registries
@@ -51,6 +52,18 @@ query_sources <- function(id,
         finally = NULL
         )
     }
+    
+    if (any(grepl("dataone.org", registries))){
+      remote <- registries[grepl("dataone.org", registries)]
+      ## Note: vectorization is unnecessary here. 
+      ## error handling to avoid failure if SWH call fails
+      swh_out <- tryCatch(
+        sources_dataone(id, host = remote),
+        error = function(e) warning(e),
+        finally = NULL
+      )
+    }
+    
   }
   
   ## Local, tsv-backed registries
@@ -76,7 +89,7 @@ query_sources <- function(id,
   }
   
   ## format return to show only most recent
-  out <- rbind(ha_out, store_out, tsv_out, swh_out, lmdb_out)
+  out <- rbind(ha_out, store_out, tsv_out, swh_out, lmdb_out, dataone_out)
   filter_sources(out, registries, cols)
 
 }

--- a/R/register.R
+++ b/R/register.R
@@ -40,6 +40,8 @@ register_ <- function(url, registries = default_registries(), ...) {
   tsv_out <- NULL
   ha_out <- NULL
   lmdb_out <- NULL
+  registries <- expand_registery_urls(registries)
+  
 
   if(curl::has_internet()){
     if (any(grepl("hash-archive", registries))) {

--- a/R/register.R
+++ b/R/register.R
@@ -84,49 +84,6 @@ assert_unique_id <- function(x) {
   out
 }
 
-#' default registries
-#'
-#' A helper function to conviently load the default registries
-#' @details This function is primarily useful to restrict the
-#' scope of [query_sources] or [register] to, e.g. either just the
-#' remote registry or just the local registry.  Note that a user
-#' can alter the registry on the fly by passing local paths and/or the
-#' URL (`https://hash-archive.org`) directly.
-#'
-#' @examples
-#' ## Both defaults
-#' default_registries()
-#'
-#' ## Only the fist one (local registry)
-#' default_registry()[1]
-#' \donttest{
-#' ## Alter the defaults with env var.
-#' ## here we set two local registries as the defaults
-#' Sys.setenv(CONTENTID_REGISTRIES = "store/, store2/")
-#' default_registries()
-#'
-#' Sys.unsetenv(CONTENTID_REGISTRIES)
-#' }
-#' @noRd
-# @export
-default_registries <- function() {
-  registries <- strsplit(
-    Sys.getenv(
-      "CONTENTID_REGISTRIES",
-      paste(
-        
-        default_tsv(),                           ## local registry
-        "https://hash-archive.org",              ## Hash Archives
-        "https://archive.softwareheritage.org",  ## Only for query, not register
-        content_dir(),                           ## Local stores
-        sep = ", "
-      )
-    ),
-    ", "
-  )[[1]]
-
-  registries
-}
 
 
 

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -87,8 +87,9 @@ attempt_source <- function(entries, verify = TRUE) {
 
     ##
     if (verify) {
+        algo <- sub(hashuri_regex, "\\1", entries[i, "identifier"])
         ## verification is always sha256-based.  
-        id <- content_id(source_loc, "sha256")
+        id <- content_id(source_loc, algo)
         if (id == entries[i, "identifier"]) {
           return(source_loc)
         } else {

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -57,7 +57,8 @@ resolve <- function(id,
   path <- attempt_source(df, verify = verify)
   
   if(store){
-    id_sha256 <- store(path, dir = dir)
+    algo <- extract_algo(id)
+    id_sha256 <- store(path, dir = dir, algos = algo)
     path <- retrieve(id_sha256, dir = dir) 
   }
   

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -44,7 +44,7 @@ resolve <- function(id,
                     registries = default_registries(),
                     verify = TRUE,
                     store = FALSE,
-                    dir = registries[dir.exists(registries)][[1]],
+                    dir = content_dir(),
                     ...) {
   
   df <- query_sources(id, registries, cols=c("identifier", "source", "date"), ...)
@@ -57,8 +57,8 @@ resolve <- function(id,
   path <- attempt_source(df, verify = verify)
   
   if(store){
-    store(path, dir = dir)
-    path <- retrieve(id, dir = dir) 
+    id_sha256 <- store(path, dir = dir)
+    path <- retrieve(id_sha256, dir = dir) 
   }
   
   path

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -53,9 +53,14 @@ retrieve <- function(id, dir = content_dir()) {
 }
 
 
-store_list <- function(dir = content_dir()){
-  fs::dir_info(path = fs::path(dir, "data"), recurse = TRUE, type = "file")
+
+# function not in use...
+store_list <- function(dir = content_dir(), algos = default_algos()){
+  # include symlinks? 
+  fs::dir_info(path = fs::path(dir, algos), recurse = TRUE, type = "file")
 }
+
+
 
 store_delete <- function(ids, dir = content_dir()){
   lapply(ids, function(id){ 

--- a/R/software-heritage.R
+++ b/R/software-heritage.R
@@ -20,14 +20,14 @@
 #' }
 #' 
 sources_swh <- function(id, host = "https://archive.softwareheritage.org", ...){
-  
+  quiet <- getOption("verbose", FALSE)
   id <- as_hashuri(id)
   if(is.na(id)){
     warning(paste("id", id, "not recognized as a valid identifier"), call. = FALSE)
     return( null_query() )
   }
   if(!grepl("sha256", id)){
-    message(paste("skipping Software Heritage as id is not a SHA256 sum"))
+    if(!quiet) message(paste("skipping Software Heritage as id is not a SHA256 sum"))
     return( null_query() )
   }
 

--- a/R/software-heritage.R
+++ b/R/software-heritage.R
@@ -26,6 +26,10 @@ sources_swh <- function(id, host = "https://archive.softwareheritage.org", ...){
     warning(paste("id", id, "not recognized as a valid identifier"), call. = FALSE)
     return( null_query() )
   }
+  if(!grepl("sha256", id)){
+    message(paste("skipping Software Heritage as id is not a SHA256 sum"))
+    return( null_query() )
+  }
 
   endpoint <- "/api/1/content/sha256:"
   hash <- strip_prefix(id)

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,7 +30,9 @@ download_resource <- function(x) {
 
 ## These should be much more general!
 add_prefix <- function(x) paste0("hash://sha256/", x)
-strip_prefix <- function(x) gsub("^hash://sha256/", "", x)
+strip_prefix <- function(x) gsub(hashuri_regex, "\\2", x)
+extract_algo <- function(x) gsub(hashuri_regex, "\\1", x)
+
 is_url <- function(x) grepl("^((http|ftp)s?|sftp)://", x)
 
 

--- a/man/resolve.Rd
+++ b/man/resolve.Rd
@@ -9,7 +9,7 @@ resolve(
   registries = default_registries(),
   verify = TRUE,
   store = FALSE,
-  dir = registries[dir.exists(registries)][[1]],
+  dir = content_dir(),
   ...
 )
 }

--- a/man/store.Rd
+++ b/man/store.Rd
@@ -4,7 +4,7 @@
 \alias{store}
 \title{Store files in a local cache}
 \usage{
-store(x, dir = content_dir())
+store(x, dir = content_dir(), algos = default_algos())
 }
 \arguments{
 \item{x}{a URL, \link{connection}, or file path.}
@@ -13,6 +13,9 @@ store(x, dir = content_dir())
 of the registry. An appropriate default will be selected (also
 configurable using the environmental variable \code{CONTENTID_HOME}),
 if not specified.}
+
+\item{algos}{Which algorithms should we compute contentid for? Default
+"sha256", see details.}
 }
 \value{
 the content-based identifier

--- a/tests/testthat/test-dataone.R
+++ b/tests/testthat/test-dataone.R
@@ -7,7 +7,8 @@ test_that("we can return sources from DataONE", {
   skip_if_offline()
   skip_on_cran()
   
-  id <- paste0("hash://md5/e27c99a7f701dab97b7d09c467acf468")
+  # id <- "hash://md5/e27c99a7f701dab97b7d09c467acf468"
+  id <- "hash://md5/2ac33190eab5a5c739bad29754532d76"
   df <- sources_dataone(id)
   expect_is(df, "data.frame")
   expect_gt(nrow(df), 0)
@@ -16,8 +17,9 @@ test_that("we can return sources from DataONE", {
   expect_is(df, "data.frame")
   expect_gt(nrow(df), 0)
   
-  x <- resolve(id, registries = "https://cn.dataone.org")
-  
+  x <- resolve(id,  registries = "https://cn.dataone.org")
+  df <- read.table(x, skip=21)
+  expect_gt(nrow(df), 0)
 })
 
 

--- a/tests/testthat/test-dataone.R
+++ b/tests/testthat/test-dataone.R
@@ -20,6 +20,11 @@ test_that("we can return sources from DataONE", {
   x <- resolve(id,  registries = "dataone", store = TRUE)
   df <- read.table(x, skip=21)
   expect_gt(nrow(df), 0)
+  
+  # should have a local source now too
+  df <- query_sources(id, registries = c("dataone", content_dir()))
+  expect_gt(nrow(df), 1)
+  
 })
 
 

--- a/tests/testthat/test-dataone.R
+++ b/tests/testthat/test-dataone.R
@@ -1,0 +1,35 @@
+
+context("DataONE")
+ 
+
+test_that("we can return sources from DataONE", {
+  
+  skip_if_offline()
+  skip_on_cran()
+  
+  id <- paste0("hash://md5/e27c99a7f701dab97b7d09c467acf468")
+  df <- sources_dataone(id)
+  expect_is(df, "data.frame")
+  expect_gt(nrow(df), 0)
+  
+  df <- query_sources(id, registries = "https://cn.dataone.org")
+  expect_is(df, "data.frame")
+  expect_gt(nrow(df), 0)
+  
+  x <- resolve(id, registries = "https://cn.dataone.org")
+  
+})
+
+
+test_that("we return missing hashes gracefully from DataONE", {
+  
+  skip_if_offline()
+  skip_on_cran()
+  
+  id <- paste0("hash://sha256/9412325831dab22aeebdd",
+               "674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37")
+  df <- sources_dataone(id)
+  expect_is(df, "data.frame")
+  expect_equal(nrow(df), 0)
+  
+})

--- a/tests/testthat/test-dataone.R
+++ b/tests/testthat/test-dataone.R
@@ -13,11 +13,11 @@ test_that("we can return sources from DataONE", {
   expect_is(df, "data.frame")
   expect_gt(nrow(df), 0)
   
-  df <- query_sources(id, registries = "https://cn.dataone.org")
+  df <- query_sources(id, registries = "dataone")
   expect_is(df, "data.frame")
   expect_gt(nrow(df), 0)
   
-  x <- resolve(id,  registries = "https://cn.dataone.org")
+  x <- resolve(id,  registries = "dataone", store = TRUE)
   df <- read.table(x, skip=21)
   expect_gt(nrow(df), 0)
 })


### PR DESCRIPTION
This adds support to query DataONE SOLR API for a hash and return the corresponding `dataUrl` if found.  For example:

```r
tmp <- contentid::resolve("hash://md5/2ac33190eab5a5c739bad29754532d76")
df <- read.csv(tmp)
```
This adds the DataONE central node as a default registry, which means that any `resolve()` request (or `query_sources()` request) will ping the DataONE SOLR API for the hash in question.

@mbjones please let me know if that's not a good a default.  Also let me know if you'd prefer we do this a different way; as you can see in the source-code, we currently do this as query for a matching `checksum` value and then extract the corresponding data url.  

Note that the registry can be set explicitly to dataone by providing that as the only registry in the list:

```r
tmp <- contentid::resolve("hash://md5/2ac33190eab5a5c739bad29754532d76", 
                                         registries = "https://cn.dataone.org")
df <- read.csv(tmp)
```

If we don't want to always hit dataone by default, then this would provide an opt-in way to query it. (Or the user can configure all of their preferred defaults using the env var `CONTENTID_REGISTRIES`, see `?default_registries()` for details)

Addresses https://github.com/NCEAS/fairdataone/issues/2

Note: currently the DataONE search landing pages do not display content hash information, nor is it typically included in the EML.  Consequently, it is somewhat more clunky than it might be to determine which hash DataONE is using for any given object in its collection. It would be convenient if the web interface could make this easier to discover without the solr API.  