### PR TITLE
Refactor for more pluggable interface

### DIFF
--- a/R/dataone_registry.R
+++ b/R/dataone_registry.R
@@ -2,7 +2,7 @@
 
 
 # @examples \donttest{
-# id <- paste0("hash://md5/e27c99a7f701dab97b7d09c467acf468")
+# id <- "hash://md5/e27c99a7f701dab97b7d09c467acf468"
 # sources_dataone(id)
 # }
 sources_dataone <- function(id, host = "https://cn.dataone.org"){

--- a/R/dataone_registry.R
+++ b/R/dataone_registry.R
@@ -5,7 +5,7 @@
 # id <- paste0("hash://md5/e27c99a7f701dab97b7d09c467acf468")
 # sources_dataone(id)
 # }
-sources_dataone <- function(id, host = "https://cn.dataone.org/"){
+sources_dataone <- function(id, host = "https://cn.dataone.org"){
   hash <- gsub("^hash://\\w+/", "", id)
   query <- paste0(host, "/cn/v2/query/solr/","?q=checksum:",hash,
                   "&fl=identifier,size,formatId,checksum,checksumAlgorithm,",
@@ -18,7 +18,7 @@ sources_dataone <- function(id, host = "https://cn.dataone.org/"){
   } 
   sources <- sources[[1]]
   size <- lapply(out$response$docs, `[[`,"size")[[1]]
-  out <- registry_entry(id, source = sources, date = Sys.time())
+  out <- registry_entry(id, source = sources, date = Sys.time(), size = size)
 
 }
 
@@ -27,8 +27,8 @@ sources_dataone <- function(id, host = "https://cn.dataone.org/"){
 # sources_dataone(id)
 # }
 # 
-retrieve_dataone <- function(id, baseURL = "https://cn.dataone.org/cn/"){
-  df <- sources_dataone(id, baseURL)
+retrieve_dataone <- function(id, host = "https://cn.dataone.org"){
+  df <- sources_dataone(id, host)
   df$source
 }
 

--- a/R/default_registries.R
+++ b/R/default_registries.R
@@ -31,8 +31,9 @@ default_registries <- function() {
       paste(
         default_tsv(),                           ## local registry
         "https://hash-archive.org",              ## Hash Archives
-        "https://archive.softwareheritage.org",  ## Only for query, not register
-        "https://cn.dataone.org",                ## Only for query, not register
+        "https://archive.softwareheritage.org",  
+        "https://cn.dataone.org",
+        "https://zenodo.org",
         content_dir(),                           ## Local stores
         sep = ", "
       )

--- a/R/hash-archive.R
+++ b/R/hash-archive.R
@@ -26,7 +26,16 @@ register_ha <- function(url, host = "https://hash-archive.org", ...) {
   
   endpoint <- "api/enqueue"
   request <- paste(host, endpoint, url, sep = "/")
-  response <- httr::GET(request)
+  limit <- getOption("contentid_register_timeout", 2)
+  response <- tryCatch(
+    httr::GET(request, httr::timeout(limit)),
+    error = function(e){
+      warning(paste(e), call. = FALSE)
+      NA
+    },
+    finally = NA
+  )
+  if(all(is.na(response))) return(NA_character_)
   httr::stop_for_status(response)
   result <- httr::content(response, "parsed", "application/json")
   

--- a/R/pin.R
+++ b/R/pin.R
@@ -42,7 +42,10 @@
 #' Sys.unsetenv("CONTENTID_REGISTRIES")
 #' Sys.unsetenv("CONTENTID_HOME")
 #' }
-pin <- function(url, verify = TRUE, dir = content_dir()) {
+pin <- function(url, 
+                verify = TRUE, 
+                dir = content_dir(), 
+                registries = "https://hash-archive.org") {
   
   if(!verify){
     return(unverified_resolver(url, dir))
@@ -51,11 +54,14 @@ pin <- function(url, verify = TRUE, dir = content_dir()) {
   # Have hash-archive.org compute the identifier. Its high bandwidth
   # and fast processors will probably do so faster than local computation
   
-  id <- register(url, registries = "https://hash-archive.org")
-  
-  ## resolve the curent content id.  If it matches a cached copy, resolve
+  id <- register(url, registries = registries)
+  if(is.na(id)){
+    warning(paste("Unable to register", url), call.=FALSE)
+    return(NA)
+  }
+  ## resolve the current content id.  If it matches a cached copy, resolve
   ## will use that.  If it does not, resolve will download the latest version
-  resolve(id, registries = "https://hash-archive.org", store = TRUE, dir = dir)
+  resolve(id, registries = registries, store = TRUE, dir = dir)
 }
 
 

--- a/R/query_history.R
+++ b/R/query_history.R
@@ -37,7 +37,7 @@ query_history <- function(url, registries = default_registries(), ...){
   tsv_out <- NULL
   lmdb_out <- NULL
   
-  registries <- expand_registery_urls(registries)
+  registries <- expand_registry_urls(registries)
   
 
   ## Remote host registries  (hash-archive.org type only)

--- a/R/query_history.R
+++ b/R/query_history.R
@@ -13,6 +13,15 @@
 #' may no longer be available, though there is a chance it has been registered
 #' to a different url and can be resolved with [query_sources].
 #' @seealso sources
+#' @details query_history() only applies to registries that contain mutable URLs,
+#' i.e. hash-archive and local registries which merely record the contents last
+#' seen at any URL.  Such URLs may have the same or different content at a later
+#' date, or may fail to resolve.  In contrast, archives such as DataONE or 
+#' Zenodo that resolve identifiers to source URLs control both the registry and 
+#' the content storage, and thus only report URLs where content is currently found.
+#' While Download URLs from archives may move and old URLs may fail, a download URL
+#' never has "history" of different content (e.g. different versions) served 
+#' from the same access URL.  
 #' @export
 #' @importFrom methods is
 #' @examples
@@ -38,29 +47,35 @@ query_history <- function(url, registries = default_registries(), ...){
   lmdb_out <- NULL
   
   registries <- expand_registry_urls(registries)
-  
-
-  ## Remote host registries  (hash-archive.org type only)
-  if (any(grepl("hash-archive.org", registries))){
-    remote <- registries[grepl("hash-archive.org", registries)]  
-    ha_out <- lapply(remote, function(host) history_ha(url, host = host))
-    ha_out <- do.call(rbind, ha_out)
-  }
-  
-  if(any(is(registries, "mdb_env"))){
-    local <- registries[is(registries, "mdb_env")]
-    lmdb_out <- lapply(local, function(lmdb) history_lmdb(url, lmdb))
-    lmdb_out <- do.call(rbind, lmdb_out)
-  }
+  types <- detect_registry_type(registries)
   
   
-  ## Local, tsv-backed registries
-  if(any(is_path_tsv(registries))){
-    local <- registries[is_path_tsv(registries)]
-    tsv_out <- lapply(local, function(tsv) history_tsv(url, tsv = tsv))
-    tsv_out <- do.call(rbind, tsv_out)
-  }
+  ## Call sources_fn on each recognized registry type
+  out <- lapply(types, function(type){
+    active_registries <- registries[types == type]
+    generic_history(url, registries = active_registries, type = type)
+  })
   
-  rbind(ha_out, tsv_out, lmdb_out)
-  
+  do.call(rbind, out)
 }
+
+## Map (closure) to select the history_* function for the type
+known_history <- function(type){ 
+  switch(type,
+         "hash-archive" = history_ha,
+         "tsv" = history_tsv,
+         "lmdb" = history_lmdb,
+         function(url, host) NULL
+  )
+}
+generic_history <- function(url, registries, type){
+  out <- lapply(registries, 
+                function(host){
+                  tryCatch(known_history(type)(url, host),
+                           error = function(e) warning(e),
+                           finally = NULL)
+                })
+  do.call(rbind,out)
+}
+
+

--- a/R/query_sources.R
+++ b/R/query_sources.R
@@ -27,95 +27,80 @@ query_sources <- function(id,
                           cols = c("source", "date"), 
                           ...){
   
-  ha_out <- NULL
-  tsv_out <- NULL
-  lmdb_out <- NULL
-  store_out <- NULL
-  swh_out <- NULL
-  dataone_out <- NULL
+  registries <- expand_registry_urls(registries)
+  types <- detect_registry_type(registries)
   
-  
-  registries <- expand_registery_urls(registries)
-  
-  if(curl::has_internet()){
-    ## Remote hash-archive.org type registries
-    if (any(grepl("hash-archive", registries))){
-      remote <- registries[grepl("hash-archive", registries)]
-      ha_out <- lapply(remote, function(host) sources_ha(id, host = host))
-      ha_out <- do.call(rbind, ha_out)
+  ## Call sources_fn on each recognized registry type
+  out <- lapply(types, function(type){
+    active_registries <- registries[types == type]
+    # select the sources_fn and call safely
+    safe_query <- function(host){
+      tryCatch(sources_fn(type)(id, host),
+               error = function(e) warning(e),
+               finally = NULL)
     }
-    
-    if (any(grepl("softwareheritage", registries))){
-      remote <- registries[grepl("softwareheritage", registries)]
-      ## Note: vectorization is unnecessary here. 
-      ## error handling to avoid failure if SWH call fails
-      swh_out <- tryCatch(
-        sources_swh(id, host = remote),
-        error = function(e) warning(e),
-        finally = NULL
-        )
-    }
-    
-    if (any(grepl("dataone", registries))){
-      remote <- registries[grepl("dataone", registries)]
-      ## Note: vectorization is unnecessary here. 
-      ## error handling to avoid failure if SWH call fails
-      swh_out <- tryCatch(
-        sources_dataone(id, host = remote),
-        error = function(e) warning(e),
-        finally = NULL
-      )
-    }
-  }
-  
-  ## Local, tsv-backed registries
-  if(any(is_path_tsv(registries))){
-    local <- registries[is_path_tsv(registries)]
-    tsv_out <- lapply(local, function(tsv) sources_tsv(id, tsv))
-    tsv_out <- do.call(rbind, tsv_out)
-  }
-  
-  ## Local, LMDB-backed registries
-  if(any(is(registries, "mdb_env"))){
-    local <- registries[is(registries, "mdb_env")]
-    lmdb_out <- lapply(local, function(lmdb) sources_lmdb(id, lmdb))
-    lmdb_out <- do.call(rbind, lmdb_out)
-  }
-  
-  
-  ## local stores are automatically registries as well
-  if(any(dir.exists(registries))){
-    stores <- registries[dir.exists(registries)]
-    store_out <- lapply(stores, function(dir) sources_store(id, dir = dir))
-    store_out <- do.call(rbind, store_out)
-  }
-  
-  ## format return to show only most recent
-  out <- rbind(ha_out, store_out, tsv_out, swh_out, lmdb_out, dataone_out)
+    ## lapply+rbind to support, e.g. two .tsv registries
+    do.call(rbind,lapply(active_registries, safe_query))
+  })
+  out <- do.call(rbind, out)
   filter_sources(out, registries, cols)
 
 }
 
-
-expand_registery_urls <- function(registries) {
-  
+## Map short names into recognized URL endpoints
+expand_registry_urls <- function(registries) {
   registries[grepl("^dataone$", registries)] <- "https://cn.dataone.org"
   registries[grepl("^hash-archive$", registries)] <- "https://hash-archive.org"
   registries[grepl("softwareheritage", registries)] <- "https://archive.softwareheritage.org"
+  registries[grepl("zenodo", registries)] <- "https://zenodo.org"
   registries
-  
+}
+## Map URLs and paths to corresponding short names
+detect_registry_type <- function(registries) {
+  registries[grepl("dataone", registries)] <- "dataone"
+  registries[grepl("hash-archive", registries)] <- "hash-archive"
+  registries[grepl("softwareheritage", registries)] <- "softwareheritage"
+  registries[grepl("zenodo", registries)] <- "zenodo"
+  registries[is_path_tsv(registries)] <- "tsv"
+  registries[is(registries, "mdb_env")] <- "lmdb"
+  registries[dir.exists(registries)] <- "content_store"
+  registries
+}
+## Map (closure) to select the sources_* function for the type
+sources_fn <- function(type){ 
+  SOURCES <- list(
+  "hash-archive" = sources_ha,
+  "dataone" = sources_dataone,
+  "zenodo" = sources_zenodo,
+  "softwareheritage" = sources_swh,
+  "tsv" = sources_tsv,
+  "lmdb" = sources_lmdb,
+  "content_store" = sources_store
+  )
+  SOURCES[[type]]
 }
 
 
 
+# For a single identifier, some registries (tsv and hash-archive) can contain
+# many entries resolving that same ID to the same URL (on different dates -- i.e.
+# different "sightings" of the data at the same spot.)  We only want the most recent.
+# 
+# Some registries (tsv and hash-archive) will report URLs which are later observed
+# to be failing (i.e. have different content or error msg).  Checking query_history
+# on the URL first confirms if the URL still contains the desired content.  
+#
+# Lastly, we want to sort local matches first, and then sort by date of most recent first
+# 
 filter_sources <- function(df, 
                            registries = default_registries(), 
-                           cols = c("source", "date")
+                           col = c("source", "date")
                            ){
   
   if(is.null(df)) return(df)
   
   id_sources <- most_recent_sources(df)
+  
   
   ## Now, check history for all these URLs and see if the content is current 
   url_sources <- id_sources$source[is_url(id_sources$source)]
@@ -141,7 +126,7 @@ filter_sources <- function(df,
   out <- out[!is.na(out$status), ]
   row.names(out) <- NULL
   
-  out[cols]
+  out[col]
   
 }
 

--- a/R/register.R
+++ b/R/register.R
@@ -40,7 +40,7 @@ register_ <- function(url, registries = default_registries(), ...) {
   tsv_out <- NULL
   ha_out <- NULL
   lmdb_out <- NULL
-  registries <- expand_registery_urls(registries)
+  registries <- expand_registry_urls(registries)
   
 
   if(curl::has_internet()){

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,6 +33,8 @@ add_prefix <- function(x) paste0("hash://sha256/", x)
 strip_prefix <- function(x) gsub(hashuri_regex, "\\2", x)
 extract_algo <- function(x) gsub(hashuri_regex, "\\1", x)
 
+
+
 is_url <- function(x) grepl("^((http|ftp)s?|sftp)://", x)
 
 

--- a/R/zenodo_registry.R
+++ b/R/zenodo_registry.R
@@ -1,0 +1,40 @@
+# md5 only for now
+# id <- "hash://md5/eb5e8f37583644943b86d1d9ebd4ded5"
+sources_zenodo <- function(id, host = "https://zenodo.org"){
+  query <- "/api/records/?q=_files.checksum:"
+  hash <- strip_prefix(id)
+  algo <- extract_algo(id)
+  checksum <- paste0('"', algo, ":", hash, '"')
+  url <- paste0(host, query, checksum)
+  resp <- httr::GET(url)
+  sources <- httr::content(resp)
+  if(length(sources) == 0){
+    return(null_query())
+  } 
+  sources <- sources[[1]]
+  
+  ## The associated record may also have other files, match by id: 
+  ids <- vapply(sources$files, `[[`, character(1L), "checksum")
+  file <- sources$files[ids == hash][[1]]
+  
+  download_url <- file$links$download
+  size <- file$filesize
+  date <- sources$created
+  out <- registry_entry(id, source = download_url, size =size, date = date)
+  out
+}
+
+# @examples \donttest{
+# id <- "hash://md5/e27c99a7f701dab97b7d09c467acf468"
+# sources_zenodo(id)
+# }
+# 
+retrieve_zenodo <- function(id, host = "https://zenodo.org"){
+  df <- sources_zenodo(id, host)
+  df$source
+}
+
+## We can also "register" an identifier at zenodo by depositing the data object.
+## rather beyond the scope of a small `contentid` package.
+
+

--- a/man/pin.Rd
+++ b/man/pin.Rd
@@ -4,7 +4,12 @@
 \alias{pin}
 \title{Access the latest content at a URL}
 \usage{
-pin(url, verify = TRUE, dir = content_dir())
+pin(
+  url,
+  verify = TRUE,
+  dir = content_dir(),
+  registries = "https://hash-archive.org"
+)
 }
 \arguments{
 \item{url}{a URL to a web resource}
@@ -14,6 +19,8 @@ of content at the URL before we look for a local cache?}
 
 \item{dir}{path to the local store directory. Defaults to first local registry given to
 the \code{registries} argument.}
+
+\item{registries}{list of registries at which to register the URL}
 }
 \description{
 This will download the requested object to a local cache and return the local path of the

--- a/man/query_history.Rd
+++ b/man/query_history.Rd
@@ -24,6 +24,17 @@ to a different url and can be resolved with \link{query_sources}.
 \link{query_history} is the complement of \link{query_sources}, in that it filters a table
 of content identifier : url : date entries by the url.
 }
+\details{
+query_history() only applies to registries that contain mutable URLs,
+i.e. hash-archive and local registries which merely record the contents last
+seen at any URL.  Such URLs may have the same or different content at a later
+date, or may fail to resolve.  In contrast, archives such as DataONE or
+Zenodo that resolve identifiers to source URLs control both the registry and
+the content storage, and thus only report URLs where content is currently found.
+While Download URLs from archives may move and old URLs may fail, a download URL
+never has "history" of different content (e.g. different versions) served
+from the same access URL.
+}
 \examples{
 \dontshow{ ## Real users won't use a temporary dir
 Sys.setenv("CONTENTID_REGISTRIES" = tempdir())

--- a/paper/paper.Rmd
+++ b/paper/paper.Rmd
@@ -99,8 +99,13 @@ We have now registered the same content at two locations: a URL and a local file
 
 We can get a better sense of this process by querying for all available sources for our requested content:
 
-```{r}
-query_sources("hash://sha256/9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37")
+```{r results="hide"}
+df <- query_sources("hash://sha256/9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37")
+df
+```
+
+```{r echo=FALSE}
+kableExtra::kable(df, "latex")
 ```
 
 Note that `query_sources()` has found more locations than we have registered above.  This is because in addition to maintaining a local registry of sources, `contentid` registers online sources with the Hash Archive, <https://hash-archive.org>. (The Hash Archive doesn't store content, but only a list of public links at which content matching the hash has been seen.)  `query_sources()` has also checked for this content on the Software Heritage Archive, which does periodic crawls of all public content on GitHub which have also picked up a copy of this exact file. With each URL is a date at which it was last seen - repeated calls to `register()` will update this date, or lead to a source being deprecated for this content if the content it serves no longer matches the requested hash. We can view the history of all registrations of a given source using `query_history()`.  
@@ -132,20 +137,3 @@ Sys.unsetenv("CONTENTID_HOME")
 ```
 
 
-
-## Code formatting
-
-Don't use markdown, instead use the more precise latex commands:
-
-* \proglang{Java}
-* \pkg{plyr}
-* \code{print("abc")}
-
-# R code
-
-Can be inserted in regular R markdown blocks.
-
-```{r}
-x <- 1:10
-x
-```

--- a/tests/testthat/test-pin.R
+++ b/tests/testthat/test-pin.R
@@ -1,11 +1,12 @@
 context("pin")
 
-  ## A zenodo URL will be stable
-  url <- "https://zenodo.org/record/3678928/files/vostok.icecore.co2"
-  ## or not?
-  
-  url <- "https://knb.ecoinformatics.org/knb/d1/mn/v2/object/ess-dive-457358fdc81d3a5-20180726T203952542"
+## A zenodo URL will be stable
+url <- "https://zenodo.org/record/3678928/files/vostok.icecore.co2"
+## or not?
+url <- "https://knb.ecoinformatics.org/knb/d1/mn/v2/object/ess-dive-457358fdc81d3a5-20180726T203952542"
 
+## avoid timeouts on hash-archive.org
+hash_archive <- "https://hash-archive.thelio.carlboettiger.info"
 
 
 test_that("We can access a URL with an unverified pin", {
@@ -13,14 +14,13 @@ test_that("We can access a URL with an unverified pin", {
   skip_if_offline()
   skip_on_cran()
   
-  path <- pin(url, verify = FALSE)
+  path <- pin(url, verify = FALSE, registries = hash_archive)
   
   id <- content_id(path)
   expect_equal("hash://sha256/9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37",
                id)
   ## Should be faster now
-  ## A zenodo URL will be stable
-  path <- pin(url, verify = FALSE)
+  path <- pin(url, verify = FALSE, registries = hash_archive)
   
   
 })
@@ -31,7 +31,7 @@ test_that("We can access a URL with pin", {
   skip_if_offline()
   skip_on_cran()
   
-  path <- pin(url)
+  path <- pin(url, registries = hash_archive)
    
   id <- content_id(path)
   expect_equal("hash://sha256/9412325831dab22aeebdd674b6eb53ba6b7bdd04bb99a4dbb21ddff646287e37",

--- a/tests/testthat/test-remote_api.R
+++ b/tests/testthat/test-remote_api.R
@@ -6,16 +6,21 @@ test_that("We can register & retrieve content from the remote API", {
 
   ## A zenodo URL will be stable
   url <- "https://zenodo.org/record/3678928/files/vostok.icecore.co2"
-  ## or not?
+  ## or not.... use KNB
   url <- "https://knb.ecoinformatics.org/knb/d1/mn/v2/object/ess-dive-457358fdc81d3a5-20180726T203952542"
+  ## Or use this zenodo download url:
   
-  id <- register(
-    url,
-    "https://hash-archive.org")
+  
+  ## hash-archive.org may timeout more often these days...
+  hash_archive <- "https://hash-archive.thelio.carlboettiger.info"
+  
+  id <- register(url,hash_archive)
+  
+  
   expect_is(id, "character")
 
   
-  df <- query(id, registries = "https://hash-archive.org")
+  df <- query(id, registries = hash_archive)
   expect_is(df, "data.frame")
   expect_true(dim(df)[1] > 1)
 


### PR DESCRIPTION
- Refactor `query_history()` and `query_sources()` to be more easily extensible
- Add Zenodo into the list of default registries 


This means that content identifiers can be resolved against Zenodo sources as well.  Note that at this time, Zenodo only supports `md5`-based checksums, for which collisions are possible (though unlikely).  

```r
contentid:::sources_zenodo("hash://md5/e27c99a7f701dab97b7d09c467acf468")
```

```
                                   identifier                                                                               source       date  size status                                         md5 sha1 sha256 sha384 sha512
1 hash://md5/e27c99a7f701dab97b7d09c467acf468 https://zenodo.org/api/files/5967f986-b599-4492-9a08-94ce32323dc2/vostok.icecore.co2 2020-02-22 11036    200 hash://md5/e27c99a7f701dab97b7d09c467acf468 <NA>   <NA>   <NA>   <NA>
```

Consequently, functions such as `resolve()` or `query_sources()` can now successfully resolve to content found in the Zenodo archive.  

Hopefully at some point Zenodo will consider sha256