### PR TITLE
patch check_url, closes #70

### DIFF
--- a/R/content_id.R
+++ b/R/content_id.R
@@ -135,8 +135,10 @@ check_url <- function(file){
     }
   }
   handle <- curl::new_handle(nobody = TRUE, 
-                             customrequest = "GET",
-                             http09_allowed = TRUE)
+                             customrequest = "GET")
+  if(utils::compareVersion(curl_version(), "7.64.0") >= 0){
+    handle <- curl::handle_setopt(http09_allowed = TRUE)
+  }
   resp <- curl::curl_fetch_memory(file, handle)
   if(! "status_code" %in% names(resp))  return(404L)
   code <- resp$status

--- a/R/content_id.R
+++ b/R/content_id.R
@@ -137,7 +137,7 @@ check_url <- function(file){
   ver <- curl::curl_version()
   handle <- curl::new_handle(nobody = TRUE, 
                              customrequest = "GET")
-  if(utils::compareVersion(ver$version, "7.64.0") >= 0){
+  if(utils::compareVersion(ver$version, "7.68.0") >= 0){
     handle <- curl::handle_setopt(handle, http09_allowed = TRUE)
   }
   resp <- curl::curl_fetch_memory(file, handle)

--- a/R/content_id.R
+++ b/R/content_id.R
@@ -134,9 +134,10 @@ check_url <- function(file){
       return(404L)
     }
   }
-  resp <- curl::curl_fetch_memory(file,
-                                  handle = curl::new_handle(nobody = TRUE, 
-                                                            customrequest = "GET"))
+  handle <- curl::new_handle(nobody = TRUE, 
+                             customrequest = "GET",
+                             http09_allowed = TRUE)
+  resp <- curl::curl_fetch_memory(file, handle)
   if(! "status_code" %in% names(resp))  return(404L)
   code <- resp$status
   code

--- a/R/content_id.R
+++ b/R/content_id.R
@@ -125,15 +125,12 @@ try_multihash <- function(con, algos){
 
 
 #' @importFrom httr HEAD status_code http_status
-check_url <- function(file, warn = TRUE){
-  if(!is.character(file)) return(200L)  # Connection objects
-  if(!is_url(file)) return(200L)        # local file paths
-  resp <- httr::HEAD(file)
-  code <- httr::status_code(resp)
-  status <- httr::http_status(resp)
-  if(code >= 400L && warn){
-      warning(status$message, call. = FALSE)
-  }
+check_url <- function(file){
+  resp <- curl::curl_fetch_memory(file,
+                                  handle = curl::new_handle(nobody = TRUE, 
+                                                            customrequest = "GET"))
+  if(! "status_code" %in% names(resp))  return(404L)
+  code <- resp$status
   code
 }
 

--- a/R/content_id.R
+++ b/R/content_id.R
@@ -126,6 +126,14 @@ try_multihash <- function(con, algos){
 
 #' @importFrom httr HEAD status_code http_status
 check_url <- function(file){
+  if(!is.character(file)) return(200L)  # Connection objects
+  if(!is_url(file)){
+    if(file.exists(file)){ 
+      return(200L) 
+    } else {
+      return(404L)
+    }
+  }
   resp <- curl::curl_fetch_memory(file,
                                   handle = curl::new_handle(nobody = TRUE, 
                                                             customrequest = "GET"))

--- a/R/content_id.R
+++ b/R/content_id.R
@@ -134,10 +134,11 @@ check_url <- function(file){
       return(404L)
     }
   }
+  ver <- curl::curl_version()
   handle <- curl::new_handle(nobody = TRUE, 
                              customrequest = "GET")
-  if(utils::compareVersion(curl_version(), "7.64.0") >= 0){
-    handle <- curl::handle_setopt(http09_allowed = TRUE)
+  if(utils::compareVersion(ver$version, "7.64.0") >= 0){
+    handle <- curl::handle_setopt(handle, http09_allowed = TRUE)
   }
   resp <- curl::curl_fetch_memory(file, handle)
   if(! "status_code" %in% names(resp))  return(404L)


### PR DESCRIPTION
thanks @noamross, maybe you can take a quick glance at this?

Do you know if anything needs to be done wrt to the manual creation of the `handle` here?  (i.e. does it need to be manually destroyed; any concern about generating a new handle each time, etc?)

Also not sure if this ought to be more robust the handling of error cases for `curl_fetch_memory` -- any thoughts?