### PR TITLE
query local first, return early on success #74

### DIFF
--- a/R/resolve.R
+++ b/R/resolve.R
@@ -47,7 +47,8 @@ resolve <- function(id,
                     dir = content_dir(),
                     ...) {
   
-  df <- query_sources(id, registries, cols=c("identifier", "source", "date"), ...)
+  df <- query_sources(id, registries, cols=c("identifier", "source", "date"), 
+                      all = FALSE, ...)
   
   if(is.null(df) || nrow(df) == 0){
     warning(paste("No sources found for", id))

--- a/man/query_sources.Rd
+++ b/man/query_sources.Rd
@@ -8,6 +8,7 @@ query_sources(
   id,
   registries = default_registries(),
   cols = c("source", "date"),
+  all = TRUE,
   ...
 )
 }
@@ -16,13 +17,18 @@ query_sources(
 
 \item{registries}{list of registries at which to register the URL}
 
-\item{cols}{names of columns to keep. Default are \code{source} and \code{date}.  See details.}
+\item{cols}{names of columns to keep. Default are \code{source} and \code{date}.
+See details.}
+
+\item{all}{should we query remote registries even if a local source is found?
+Default TRUE}
 
 \item{...}{additional arguments}
 }
 \value{
 a data frame with all registration events when a URL or
-a local path (including the local store) have contained the corresponding content.
+a local path (including the local store) have contained the corresponding
+content.
 }
 \description{
 List all known URL sources for a given Content URI

--- a/tests/testthat/test-remote_api.R
+++ b/tests/testthat/test-remote_api.R
@@ -8,11 +8,10 @@ test_that("We can register & retrieve content from the remote API", {
   url <- "https://zenodo.org/record/3678928/files/vostok.icecore.co2"
   ## or not.... use KNB
   url <- "https://knb.ecoinformatics.org/knb/d1/mn/v2/object/ess-dive-457358fdc81d3a5-20180726T203952542"
-  ## Or use this zenodo download url:
-  
   
   ## hash-archive.org may timeout more often these days...
-  hash_archive <- "https://hash-archive.thelio.carlboettiger.info"
+  hash_archive <- "https://hash-archive.org"
+  hash_archive <- "https://hash-archive.carlboettiger.info"
   
   id <- register(url,hash_archive)
   
@@ -22,7 +21,7 @@ test_that("We can register & retrieve content from the remote API", {
   
   df <- query(id, registries = hash_archive)
   expect_is(df, "data.frame")
-  expect_true(dim(df)[1] > 1)
+  expect_true(dim(df)[1] >= 1)
 
   ## Should the unit test verify the hash returned?
 })


### PR DESCRIPTION
@noamross want to give this a quick spin? Should fix #74 by allowing `resolve` to return early if it finds a local match.  Otherwise, it will check the remote registries.  